### PR TITLE
No DB changes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -14,6 +14,7 @@ parameterStructureFolder = realm/
 [TESTS]
 containerFolder = realm/validation/
 database = false
+nodb = true
 
 [REPORTING]
 reportOutputFolder = realm/validation/

--- a/config.ini
+++ b/config.ini
@@ -14,7 +14,7 @@ parameterStructureFolder = realm/
 [TESTS]
 containerFolder = realm/validation/
 database = false
-nodb = true
+nodb = false
 
 [REPORTING]
 reportOutputFolder = realm/validation/

--- a/filesystemtest/fileres/as/as.json
+++ b/filesystemtest/fileres/as/as.json
@@ -1,0 +1,30 @@
+{
+    "name": "as4",
+    "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/rg3/providers/Microsoft.Compute/availabilitySets/as4",
+    "type": "Microsoft.Compute/availabilitySets",
+    "location": "eastus2",
+    "tags": {
+        "PRODUCT_LINE": "Cloud-Team",
+        "PRODUCT_NAME": "Cloud-Infrastructure",
+        "COST_CENTER": "7251",
+        "BUSINESS_OWNER": "Cloud-Team",
+        "ASSET_OWNER": "Cloud-Team",
+        "DATA_CLASSIFICATION": "Not-Applicable",
+        "ENVIRONMENT": "P",
+        "APPLICATION_NAME": "dnsntp",
+        "DR_RECOVERY_PRIORITY": "P1",
+        "RESOURCE_TIER": "Not-Applicable",
+        "MAINTENANCE_WINDOW": "Not-Applicable",
+        "RESOURCE_REQUESTED_BY": "Cloud-Team",
+        "RESOURCE_UPTIME": "24X7",
+        "RESOURCE_CREATED_DATE": "20180809",
+        "RESOURCE_EXPIRATION_DATE": "Never"
+    },
+    "properties": {
+        "platformUpdateDomainCount": 3,
+        "platformFaultDomainCount": 2
+    },
+    "sku": {
+        "name": "Aligned"
+    }
+}

--- a/filesystemtest/fileres/vn/vn.json
+++ b/filesystemtest/fileres/vn/vn.json
@@ -1,0 +1,83 @@
+{
+  "name": "vnet-hub",
+  "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/vnet-test/providers/Microsoft.Network/virtualNetworks/vnet-hub",
+  "etag": "W/\"2829b391-cf95-43dc-9a5f-502d63349481\"",
+  "type": "Microsoft.Network/virtualNetworks",
+  "location": "eastus2",
+  "properties": {
+    "provisioningState": "Succeeded",
+    "resourceGuid": "cb3a2e1a-91bb-47d1-ae75-04a2fbf8a35e",
+    "addressSpace": {
+      "addressPrefixes": [
+        "12.3.0.0/16"
+      ]
+    },
+    "subnets": [
+      {
+        "name": "default",
+        "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/vnet-test/providers/Microsoft.Network/virtualNetworks/vnet-hub/subnets/default",
+        "etag": "W/\"2829b391-cf95-43dc-9a5f-502d63349481\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "addressPrefix": "12.3.0.0/24",
+          "delegations": []
+        },
+        "type": "Microsoft.Network/virtualNetworks/subnets"
+      }
+    ],
+    "virtualNetworkPeerings": [
+      {
+        "name": "spoke1-peering",
+        "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/vnet-test/providers/Microsoft.Network/virtualNetworks/vnet-hub/virtualNetworkPeerings/spoke1-peering",
+        "etag": "W/\"2829b391-cf95-43dc-9a5f-502d63349481\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "0c9e9f54-baa5-011f-3489-53b0880202b1",
+          "peeringState": "Initiated",
+          "remoteVirtualNetwork": {
+            "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/vnet-test/providers/Microsoft.Network/virtualNetworks/vnet1"
+          },
+          "allowVirtualNetworkAccess": true,
+          "allowForwardedTraffic": false,
+          "allowGatewayTransit": false,
+          "useRemoteGateways": false,
+          "doNotVerifyRemoteGateways": false,
+          "remoteAddressSpace": {
+            "addressPrefixes": [
+              "10.2.0.0/16"
+            ]
+          },
+          "routeServiceVips": {}
+        },
+        "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+      },
+      {
+        "name": "spoke2-peering",
+        "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/vnet-test/providers/Microsoft.Network/virtualNetworks/vnet-hub/virtualNetworkPeerings/spoke2-peering",
+        "etag": "W/\"2829b391-cf95-43dc-9a5f-502d63349481\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "f70a309e-ba90-06f6-0f44-68da93239d7b",
+          "peeringState": "Initiated",
+          "remoteVirtualNetwork": {
+            "id": "/subscriptions/e43e7132-8b64-xxyy-b32d-f038bbxxyyzz/resourceGroups/vnet-test/providers/Microsoft.Network/virtualNetworks/vnet2"
+          },
+          "allowVirtualNetworkAccess": true,
+          "allowForwardedTraffic": false,
+          "allowGatewayTransit": false,
+          "useRemoteGateways": false,
+          "doNotVerifyRemoteGateways": false,
+          "remoteAddressSpace": {
+            "addressPrefixes": [
+              "11.2.0.0/16"
+            ]
+          },
+          "routeServiceVips": {}
+        },
+        "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+      }
+    ],
+    "enableDdosProtection": false,
+    "enableVmProtection": false
+  }
+}

--- a/realm/parameterStructure.json
+++ b/realm/parameterStructure.json
@@ -1,9 +1,9 @@
 {
     "fileType": "structure",
-    "companyName": "<Company Name>",
-	"type": "filesystem",
-    "gitProvider": "https://github.com/prancer-io/cloud-validation-framework.git",
+    "type": "git",
+    "companyName": "abcd",
+    "gitProvider": "https://bitbucket.org/ajeybk/mytestpub.git",
     "repoCloneAddress":"/tmp/m",
     "branchName":"master",
-    "username":"kbajey@gmail.com"
+    "username":"ajey.khanapuri@liquware.com"
 }

--- a/realm/parameterStructure3.json
+++ b/realm/parameterStructure3.json
@@ -1,0 +1,7 @@
+{
+    "fileType": "structure",
+    "type": "filesystem",
+    "companyName": "Prancer",
+    "folderPath": "filesystemtest/",
+    "username":"kbajey@gmail.com"
+}

--- a/realm/validation/nodbcontainer/gittest.json
+++ b/realm/validation/nodbcontainer/gittest.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "",
+    "contentVersion": "1.0.0.0",
+    "fileType": "test",
+    "notification": [],
+    "snapshot": "snapshotgit",
+    "testSet": [
+        {
+            "TestName": "test3",
+            "version": "0.1",
+            "cases": [
+                {
+                    "TestId": "1",
+                    "rule":"exist({11}.location)"
+                },
+                {
+                    "TestId": "2",
+                    "rule":"{11}.location='eastus2'"
+                },
+                {
+                    "TestId": "3",
+                    "rule": "exist({12}.properties.addressSpace.addressPrefixes[])"
+                },
+                {
+                    "TestId": "4",
+                    "rule": "count({12}.properties.dhcpOptions.dnsServers[])=2"
+                },
+                {
+                    "TestId": "5",
+                    "rule": "{12}.properties.subnets['name'='abc-nprod-dev-eastus2-Subnet1'].properties.addressPrefix='192.23.26.0/24'"
+                },
+                {
+                    "TestId": "6",
+                    "rule": "exist({12}.tags.OWNER)"
+                }
+            ]
+        }
+    ]
+}

--- a/realm/validation/nodbcontainer/snapshotgit.json
+++ b/realm/validation/nodbcontainer/snapshotgit.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "",
+  "contentVersion": "1.0.0.0",
+  "fileType": "snapshot",
+  "snapshots": [
+    {
+      "source": "parameterStructure3",
+      "testUser": "kbajey@gmail.com",
+      "nodes": [
+        {
+          "snapshotId": "11",
+          "type": "",
+          "collection": "customParameters",
+          "path": "fileres/as/as.json",
+          "status": "active"
+        },
+        {
+          "snapshotId": "12",
+          "type": "",
+          "collection": "customParameters",
+          "path": "fileres/vn/vn.json",
+          "status": "active"
+        }
+      ]
+    }
+  ]
+}

--- a/src/processor/comparison/comparisonantlr/rule_interpreter.py
+++ b/src/processor/comparison/comparisonantlr/rule_interpreter.py
@@ -6,7 +6,10 @@ from processor.logging.log_handler import getlogger
 from processor.comparison.comparisonantlr.compare_types import EQ, NEQ, GT, GTE, LT, LTE
 from processor.comparison.comparisonantlr.compare_types import compare_none, compare_int,\
     compare_float, compare_boolean, compare_str, compare_list
-
+from processor.helper.config.rundata_utils import get_nodb
+from processor.helper.config.config_utils import get_test_json_dir
+from processor.helper.file.file_utils import exists_file, exists_dir
+from processor.helper.json.json_utils import json_from_file
 
 comparefuncs = {
     type(None): compare_none,
@@ -130,36 +133,38 @@ class RuleInterpreter:
 
 
     def get_snaphotid_doc(self, sid):
-        dbname = self.kwargs['dbname']
-        coll = self.kwargs['snapshots'][sid] if sid in self.kwargs['snapshots'] else COLLECTION
-        docs = get_documents(coll, {'snapshotId': sid}, dbname,
-                             sort=[('timestamp', pymongo.DESCENDING)], limit=1)
-        # docs = [{
-        # "_id": "5c24af787456217c485ad1e6",
-        # "checksum": "7d814f2f82a32ea91ef37de9e11d0486",
-        # "collection": "microsoftcompute",
-        # "json":{
-        #     "id": 124,
-        #     "location": "eastus2",
-        #     "name": "mno-nonprod-shared-cet-eastus2-tab-as03"
-        # },
-        # "queryuser": "ajeybk1@kbajeygmail.onmicrosoft.com",
-        # "snapshotId": 1,
-        # "timestamp": 1545908086831
-        # }]
-        logger.debug('Number of Snapshot Documents: %s', len(docs))
         doc = None
-        if docs and len(docs):
-            doc = docs[0]['json']
-            self.snapshots.append({
-                'id': docs[0]['snapshotId'],
-                'path': docs[0]['path'],
-                'structure': docs[0]['structure'],
-                'reference': docs[0]['reference'],
-                'source': docs[0]['source']
-            })
-            # print(doc)
+        if not get_nodb():
+            dbname = self.kwargs['dbname']
+            coll = self.kwargs['snapshots'][sid] if sid in self.kwargs['snapshots'] else COLLECTION
+            docs = get_documents(coll, {'snapshotId': sid}, dbname,
+                                 sort=[('timestamp', pymongo.DESCENDING)], limit=1)
+            logger.debug('Number of Snapshot Documents: %s', len(docs))
+            if docs and len(docs):
+                doc = docs[0]['json']
+                self.snapshots.append({
+                    'id': docs[0]['snapshotId'],
+                    'path': docs[0]['path'],
+                    'structure': docs[0]['structure'],
+                    'reference': docs[0]['reference'],
+                    'source': docs[0]['source']
+                })
+        else:
+            json_dir = '%s%s' % (get_test_json_dir(), self.kwargs['container'])
+            if exists_dir(json_dir):
+                fname = '%s/snapshots/%s' % (json_dir, sid)
+                if exists_file(fname):
+                    json_data = json_from_file(fname)
+                    doc = json_data['json']
+                    self.snapshots.append({
+                        'id': json_data['snapshotId'],
+                        'path': json_data['path'],
+                        'structure': json_data['structure'],
+                        'reference': json_data['reference'],
+                        'source': json_data['source']
+                    })
         return doc
+
 
     def compare(self):
         lhs_value = self.get_value(self.lhs_operand)

--- a/src/processor/comparison/interpreter.py
+++ b/src/processor/comparison/interpreter.py
@@ -119,18 +119,18 @@ class Comparator:
     Call the factory method to create the comparator object.
     """
 
-    def __init__(self, version, dbname, collection_data, testcase):
-        self.comparator = self._factory_method(version, dbname, collection_data, testcase)
+    def __init__(self, version, container, dbname, collection_data, testcase):
+        self.comparator = self._factory_method(version, container, dbname, collection_data, testcase)
 
     @staticmethod
-    def _factory_method(version, dbname, collection_data, testcase):
+    def _factory_method(version, container, dbname, collection_data, testcase):
         version_val = version_str(version)
         if version_val == COMPARATOR_V0_1:
-            return ComparatorV01(dbname, collection_data, testcase)
+            return ComparatorV01(container, dbname, collection_data, testcase)
         elif version_val == COMPARATOR_V0_2:
-            return ComparatorV02(dbname, collection_data, testcase)
+            return ComparatorV02(container, dbname, collection_data, testcase)
         else:
-            return ComparatorV01(dbname, collection_data, testcase)
+            return ComparatorV01(container, dbname, collection_data, testcase)
 
     def validate(self):
         return self.comparator.validate()
@@ -139,7 +139,8 @@ class Comparator:
 class ComparatorV01:
     """Override the validate method to return to run comparator"""
 
-    def __init__(self, dbname, collection_data, testcase):
+    def __init__(self, container, dbname, collection_data, testcase):
+        self.container = container
         self.dbname = dbname
         self.collection_data = collection_data
         loperand = get_field_value(testcase, 'attribute')
@@ -218,7 +219,7 @@ class ComparatorV01:
                 children.append((child.getText()))
             logger.info('*' * 50)
             logger.debug("All the parsed tokens: %s", children)
-            otherdata = {'dbname': self.dbname, 'snapshots': self.collection_data}
+            otherdata = {'dbname': self.dbname, 'snapshots': self.collection_data, 'container': self.container}
             r_i = RuleInterpreter(children, **otherdata)
             result = r_i.compare()
             result_val["result"] = "passed" if result else "failed"
@@ -235,8 +236,8 @@ class ComparatorV02(ComparatorV01):
     """
     Override the validate method to run the comparisons
     """
-    def __init__(self, dbname, collection_data, testcase):
-        ComparatorV01.__init__(self, dbname, collection_data, testcase)
+    def __init__(self, container, dbname, collection_data, testcase):
+        ComparatorV01.__init__(self, container, dbname, collection_data, testcase)
 
     def validate(self):
         return ComparatorV01.validate(self)

--- a/src/processor/connector/snapshot_azure.py
+++ b/src/processor/connector/snapshot_azure.py
@@ -8,9 +8,9 @@ import time
 from processor.helper.file.file_utils import exists_file
 from processor.logging.log_handler import getlogger
 from processor.helper.config.rundata_utils import put_in_currentdata,\
-    delete_from_currentdata, get_from_currentdata
+    delete_from_currentdata, get_from_currentdata, get_nodb
 from processor.helper.json.json_utils import get_field_value, json_from_file,\
-    collectiontypes, STRUCTURE
+    collectiontypes, STRUCTURE, make_snapshots_dir, store_snapshot
 from processor.helper.httpapi.restapi_azure import get_access_token,\
     get_web_client_data, get_client_secret, json_source
 from processor.connector.vault import get_vault_data
@@ -156,7 +156,7 @@ def get_node(token, sub_name, sub_id, node, user, snapshot_source):
     return db_record
 
 
-def populate_azure_snapshot(snapshot, snapshot_type='azure'):
+def populate_azure_snapshot(snapshot, container, snapshot_type='azure'):
     """ Populates the resources from azure."""
     dbname = config_value('MONGODB', 'dbname')
     snapshot_source = get_field_value(snapshot, 'source')
@@ -196,7 +196,12 @@ def populate_azure_snapshot(snapshot, snapshot_type='azure'):
                 data = get_node(token, sub_name, sub_id, node, snapshot_user, snapshot_source)
                 if data:
                     if validate:
-                        insert_one_document(data, data['collection'], dbname)
+                        if get_nodb():
+                            snapshot_dir = make_snapshots_dir(container)
+                            if snapshot_dir:
+                                store_snapshot(snapshot_dir, data)
+                        else:
+                            insert_one_document(data, data['collection'], dbname)
                         if 'masterSnapshotId' in node:
                             snapshot_data[node['snapshotId']] = node['masterSnapshotId']
                         else:

--- a/src/processor/connector/snapshot_custom.py
+++ b/src/processor/connector/snapshot_custom.py
@@ -100,12 +100,12 @@ from git import Repo
 from git import Git
 from processor.helper.file.file_utils import exists_file, exists_dir, mkdir_path, remove_file
 from processor.logging.log_handler import getlogger
-from processor.connector.vault import get_vault_data
 from processor.helper.json.json_utils import get_field_value, json_from_file,\
-    collectiontypes, STRUCTURE, get_field_value_with_default
+    collectiontypes, STRUCTURE, get_field_value_with_default, \
+    make_snapshots_dir, store_snapshot
 from processor.helper.yaml.yaml_utils import yaml_from_file
 from processor.helper.config.config_utils import config_value, get_test_json_dir
-from processor.helper.config.rundata_utils import get_from_currentdata
+from processor.helper.config.rundata_utils import get_from_currentdata, get_nodb
 from processor.database.database import insert_one_document, sort_field, get_documents,\
     COLLECTION, DATABASE, DBNAME
 from processor.helper.httpapi.restapi_azure import json_source
@@ -507,7 +507,7 @@ def _get_repo_path(connector, snapshot):
     return None, None
 
 
-def populate_custom_snapshot(snapshot):
+def populate_custom_snapshot(snapshot, container):
     """ Populates the resources from git."""
     dbname = config_value('MONGODB', 'dbname')
     snapshot_source = get_field_value(snapshot, 'source')
@@ -530,7 +530,12 @@ def populate_custom_snapshot(snapshot):
                     data = get_node(repopath, node, snapshot, brnch, sub_data)
                     if data:
                         if validate:
-                            insert_one_document(data, data['collection'], dbname)
+                            if get_nodb():
+                                snapshot_dir = make_snapshots_dir(container)
+                                if snapshot_dir:
+                                    store_snapshot(snapshot_dir, data)
+                            else:
+                                insert_one_document(data, data['collection'], dbname)
                             if 'masterSnapshotId' in node:
                                 snapshot_data[node['snapshotId']] = node['masterSnapshotId']
                             else:

--- a/src/processor/connector/snapshot_google.py
+++ b/src/processor/connector/snapshot_google.py
@@ -19,10 +19,9 @@ from googleapiclient import discovery
 from oauth2client.service_account import ServiceAccountCredentials
 from processor.helper.file.file_utils import exists_file
 from processor.logging.log_handler import getlogger
-from processor.helper.config.rundata_utils import put_in_currentdata
+from processor.helper.config.rundata_utils import put_in_currentdata, get_nodb
 from processor.helper.json.json_utils import get_field_value, json_from_file,\
-    collectiontypes, STRUCTURE, save_json_to_file
-from processor.connector.vault import get_vault_data
+    collectiontypes, STRUCTURE, save_json_to_file, make_snapshots_dir, store_snapshot
 from processor.helper.config.config_utils import config_value, get_test_json_dir, framework_dir
 from processor.database.database import insert_one_document, sort_field, get_documents,\
     COLLECTION, DATABASE, DBNAME
@@ -170,7 +169,7 @@ def get_checksum(data):
     return checksum
 
 
-def populate_google_snapshot(snapshot):
+def populate_google_snapshot(snapshot, container):
     """
     This is an entrypoint for populating a snapshot of type google.
     All snapshot connectors should take snapshot object and based on
@@ -197,7 +196,12 @@ def populate_google_snapshot(snapshot):
                 data = get_node(compute, node, snapshot_source)
                 if data:
                     error_str = data.pop('error', None)
-                    insert_one_document(data, data['collection'], dbname)
+                    if get_nodb():
+                        snapshot_dir = make_snapshots_dir(container)
+                        if snapshot_dir:
+                            store_snapshot(snapshot_dir, data)
+                    else:
+                        insert_one_document(data, data['collection'], dbname)
                     snapshot_data[node['snapshotId']] = False if error_str else True
         except Exception as ex:
             logger.info('Unable to create Google client: %s', ex)

--- a/src/processor/connector/validation.py
+++ b/src/processor/connector/validation.py
@@ -14,6 +14,7 @@ from processor.helper.config.config_utils import config_value, get_test_json_dir
 from processor.database.database import create_indexes, COLLECTION,\
     sort_field, get_documents
 from processor.reporting.json_output import dump_output_results
+from processor.helper.config.rundata_utils import get_nodb
 
 
 logger = getlogger()
@@ -50,12 +51,13 @@ def get_snapshot_id_to_collection_dict(snapshot_file, container, dbname, filesys
             coll = node['collection'] if 'collection' in node else COLLECTION
             collection = coll.replace('.', '').lower()
             snapshot_data[sid] = collection
-            create_indexes(collection, dbname, [('timestamp', pymongo.TEXT)])
+            if not get_nodb():
+                create_indexes(collection, dbname, [('timestamp', pymongo.TEXT)])
     return snapshot_data
 
 
-def run_validation_test(version, dbname, collection_data, testcase):
-    comparator = Comparator(version, dbname, collection_data, testcase)
+def run_validation_test(version, container, dbname, collection_data, testcase):
+    comparator = Comparator(version, container, dbname, collection_data, testcase)
     result_val = comparator.validate()
     result_val.update(testcase)
     return result_val
@@ -110,7 +112,7 @@ def run_json_validation_tests(test_json_data, container, filesystem=True, snapsh
             logger.info("No testcases in testSet!...")
             continue
         for testcase in testset['cases']:
-            result_val = run_validation_test(version, dbname, collection_data,
+            result_val = run_validation_test(version, container, dbname, collection_data,
                                              testcase)
             resultset.append(result_val)
     return resultset

--- a/src/processor/helper/config/config_utils.py
+++ b/src/processor/helper/config/config_utils.py
@@ -12,6 +12,26 @@ DBTESTS = 'database'
 DBNAME = 'dbname'
 DBURL = 'dburl'
 CFGFILE = 'config.ini'
+NODB = 'nodb'
+
+def parseint(value, default=0):
+    intvalue = default
+    try:
+        intvalue = int(value)
+    except:
+        pass
+    return intvalue
+
+
+def parsebool(val, defval=False):
+    "Parse boolean from the input value"
+    retval = defval
+    if val:
+        if isinstance(val, str) and val.lower() in ['false', 'true']:
+            retval = True if val.lower() == 'true' else False
+        else:
+            retval = bool(parseint(val))
+    return retval
 
 
 def framework_currentdata():

--- a/src/processor/helper/config/rundata_utils.py
+++ b/src/processor/helper/config/rundata_utils.py
@@ -6,13 +6,23 @@ import datetime
 import json
 import socket
 import os.path
-from processor.helper.config.config_utils import framework_currentdata
+from processor.helper.config.config_utils import config_value, framework_currentdata, TESTS, NODB, parsebool
 from processor.helper.json.json_utils import json_from_file, save_json_to_file
 from processor.logging.log_handler import getlogger, FWLOGFILENAME
 from processor.helper.file.file_utils import remove_file, exists_dir, mkdir_path
 
 exclude_list = ['token', 'clientSecret', 'vaulttoken']
 logger = getlogger()
+
+def get_nodb():
+    currdata = get_currentdata()
+    if NODB in currdata:
+        nodb = currdata[NODB]
+    else:
+        nodb = parsebool(config_value(TESTS, NODB))
+        put_in_currentdata(NODB, nodb)
+    return nodb
+
 
 
 def add_to_exclude_list(key):

--- a/src/processor/helper/json/json_utils.py
+++ b/src/processor/helper/json/json_utils.py
@@ -4,7 +4,7 @@ import json
 import time
 import glob
 from collections import OrderedDict
-from processor.helper.file.file_utils import exists_file
+from processor.helper.file.file_utils import exists_file, exists_dir, mkdir_path
 from processor.helper.config.config_utils import get_test_json_dir
 from processor.logging.log_handler import getlogger
 
@@ -26,6 +26,21 @@ collectiontypes = {
     NOTIFICATIONS: 'NOTIFICATIONS'
 }
 logger = getlogger()
+
+
+def store_snapshot(snapshot_dir, data):
+    if exists_dir(snapshot_dir):
+        snapshot_file = '%s/%s' % (snapshot_dir, data['snapshotId'])
+        save_json_to_file(data, snapshot_file)
+
+
+def make_snapshots_dir(container):
+    snapshot_dir = None
+    json_dir = '%s%s' % (get_test_json_dir(), container)
+    if exists_dir(json_dir):
+        snapshot_dir = '%s/snapshots' % json_dir
+        mkdir_path(snapshot_dir)
+    return snapshot_dir
 
 
 def save_json_to_file(indata, outfile):

--- a/src/processor/helper/utils/cli_validator.py
+++ b/src/processor/helper/utils/cli_validator.py
@@ -65,26 +65,6 @@ from processor.helper.config.config_utils import framework_dir, \
 from processor.helper.file.file_utils import exists_file, exists_dir
 
 
-# def parseint(value, default=0):
-#     intvalue = default
-#     try:
-#         intvalue = int(value)
-#     except:
-#         pass
-#     return intvalue
-#
-#
-# def parsebool(val, defval=False):
-#     "Parse boolean from the input value"
-#     retval = defval
-#     if val:
-#         if isinstance(val, str) and val.lower() in ['false', 'true']:
-#             retval = True if val.lower() == 'true' else False
-#         else:
-#             retval = bool(parseint(val))
-#     return retval
-
-
 def console_log(message, cf):
     """Logger like statements only used till logger configuration is read and initialized."""
     filename = getframeinfo(cf).filename
@@ -202,10 +182,6 @@ def validator_main(arg_vals=None, delete_rundata=True):
     args = cmd_parser.parse_args(arg_vals)
 
     logger.debug("Args: %s", args)
-    # # Delete the rundata at the end of the script as per caller, default is True.
-    # if delete_rundata:
-    #     atexit.register(delete_currentdata)
-    # init_currentdata()
     try:
         logger.critical("Using Framework dir: %s", framework_dir())
         if args.db:

--- a/src/processor/helper/utils/cli_validator.py
+++ b/src/processor/helper/utils/cli_validator.py
@@ -188,6 +188,10 @@ def validator_main(arg_vals=None, delete_rundata=True):
             args.db = True if args.db == 'DB' else False
         else:
             args.db = parsebool(config_value(TESTS, DBTESTS), defval=True)
+        if args.db and nodb:
+            logger.error("Nodb and database can not be chosen together, exiting.....")
+            return 2
+
         logger.debug("Running tests from %s", "the database." if args.db else "file system.")
         put_in_currentdata('jsonsource', args.db)
         if not args.db:

--- a/src/processor/logging/log_handler.py
+++ b/src/processor/logging/log_handler.py
@@ -8,7 +8,7 @@ import os
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 from processor.helper.config.config_utils import framework_dir,\
-    get_config_data, framework_config
+    get_config_data, framework_config, TESTS, NODB, config_value
 
 
 FWLOGGER = None
@@ -127,7 +127,8 @@ def logging_fw(fwconfigfile):
     handler.setLevel(log_config['level'])
     logger.addHandler(handler)
     unittest = os.getenv('UNITTEST', "false")
-    if log_config['db'] and unittest != "true":
+    nodb = config_value(TESTS, NODB, False)
+    if log_config['db'] and unittest != "true" and not nodb:
         dblogformat = '%(asctime)s-%(message)s'
         dbhandler = MongoDBHandler(log_config['dburl'], log_config['db'])
         dbhandler.setFormatter(logging.Formatter(dblogformat))

--- a/tests/processor/comparison/test_interpreter.py
+++ b/tests/processor/comparison/test_interpreter.py
@@ -28,81 +28,81 @@ def test_interpreter(monkeypatch):
                         mock_get_documents)
     monkeypatch.setattr('processor.comparison.comparisonantlr.rule_interpreter.get_documents', mock_get_documents)
     from processor.comparison.interpreter import Comparator
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
                     "testId": "1",
                     "snapshotId": "1",
                     "attribute": "location",
                     "comparison":"exist"
                 })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "3",
         "snapshotId": "1",
         "attribute": "location.name",
         "comparison": "not exist"
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": "gt 10"
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "1",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": '"eastus2"'
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "1",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": 'len(eastus2)'
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "1",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": "'eastus2'"
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": "gt a"
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": "gt len(7)"
     })
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "location",
         "comparison": "eq '{2}.location'"
     })
-    comparator = Comparator('0.2', 'validator', {}, {
+    comparator = Comparator('0.2', 'mycontainer1', 'validator', {}, {
         "testId": "3",
         "snapshotId": "1",
         "attribute": "location.name",
         "comparison": "not exist"
     })
     comparator.validate()
-    comparator = Comparator('0.3', 'validator', {}, {
+    comparator = Comparator('0.3', 'mycontainer1', 'validator', {}, {
         "testId": "3",
         "snapshotId": "1",
         "attribute": "location.name",
         "comparison": "not exist"
     })
     comparator.validate()
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "1",
         "rule": "exist({1}.location)"
     })
     comparator.validate()
-    comparator = Comparator('0.1', 'validator', {}, {})
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {})
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "id",
@@ -110,7 +110,7 @@ def test_interpreter(monkeypatch):
     })
     val = comparator.validate()
     assert 'passed' == val['result']
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId1": "1",
         "attribute": "id",
@@ -124,14 +124,14 @@ def test_interpreter_1(monkeypatch):
     monkeypatch.setattr('processor.comparison.interpreter.get_documents',
                         mock_zero_get_documents)
     from processor.comparison.interpreter import Comparator
-    comparator = Comparator('0.1', 'validator', {}, {
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "id",
         "comparison": "gt 10"
     })
     val = comparator.validate()
-    comparator = Comparator('0.1', 'validator', {}, {})
+    comparator = Comparator('0.1', 'mycontainer1', 'validator', {}, {})
     val = comparator.validate()
 
 def atest_comparator():

--- a/tests/processor/connector/test_snapshot.py
+++ b/tests/processor/connector/test_snapshot.py
@@ -81,15 +81,15 @@ def test_populate_snapshot(monkeypatch):
     monkeypatch.setattr('processor.connector.snapshot_google.populate_google_snapshot',
                         mock_populate_google_snapshot)
     from processor.connector.snapshot import populate_snapshot
-    assert {} == populate_snapshot({})
-    assert {} == populate_snapshot({'type': 'azure'})
-    assert {} == populate_snapshot({'type': 'azure', 'nodes': [{'a': 'b'}]})
-    assert {} == populate_snapshot({'type': 'git'})
-    assert {} == populate_snapshot({'type': 'git', 'nodes': [{'a': 'b'}]})
-    assert {} == populate_snapshot({'type': 'aws'})
-    assert {} == populate_snapshot({'type': 'aws', 'nodes': [{'a': 'b'}]})
-    assert {} == populate_snapshot({'type': 'google'})
-    assert {} == populate_snapshot({'type': 'google', 'nodes': [{'a': 'b'}]})
+    assert {} == populate_snapshot({}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'azure'}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'azure', 'nodes': [{'a': 'b'}]}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'git'}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'git', 'nodes': [{'a': 'b'}]}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'aws'}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'aws', 'nodes': [{'a': 'b'}]}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'google'}, 'mycontainer1')
+    assert {} == populate_snapshot({'type': 'google', 'nodes': [{'a': 'b'}]}, 'mycontainer1')
 
 
 
@@ -99,15 +99,15 @@ def test_populate_snapshots_from_json(monkeypatch):
     monkeypatch.setattr('processor.connector.snapshot_custom.populate_custom_snapshot',
                         mock_populate_git_snapshot)
     from processor.connector.snapshot import populate_snapshots_from_json
-    assert {} == populate_snapshots_from_json({})
-    assert {} == populate_snapshots_from_json({'snapshots': []})
+    assert {} == populate_snapshots_from_json({}, 'mycontainer1')
+    assert {} == populate_snapshots_from_json({'snapshots': []}, 'mycontainer1')
     testdata = {
         'snapshots': [
             {'type': 'azure', 'nodes': [{'a': 'b'}]},
             {'type': 'git', 'nodes': [{'a': 'b'}]}
         ]
     }
-    assert {} == populate_snapshots_from_json(testdata)
+    assert {} == populate_snapshots_from_json(testdata, 'mycontainer1')
 
 
 def test_populate_snapshots_from_file(monkeypatch, create_temp_dir, create_temp_json):
@@ -116,7 +116,7 @@ def test_populate_snapshots_from_file(monkeypatch, create_temp_dir, create_temp_
     monkeypatch.setattr('processor.connector.snapshot_custom.populate_custom_snapshot',
                         mock_populate_git_snapshot)
     from processor.connector.snapshot import populate_snapshots_from_file
-    assert {} == populate_snapshots_from_file('/tmp/xyza')
+    assert {} == populate_snapshots_from_file('/tmp/xyza', 'mycontainer1')
     newpath = create_temp_dir()
     testdata = {
         'snapshots': [
@@ -125,7 +125,7 @@ def test_populate_snapshots_from_file(monkeypatch, create_temp_dir, create_temp_
         ]
     }
     fname = create_temp_json(newpath, data=testdata)
-    assert {} == populate_snapshots_from_file('%s/%s' % (newpath, fname))
+    assert {} == populate_snapshots_from_file('%s/%s' % (newpath, fname), 'mycontainer1')
 
 
 def test_empty_snapshot_populate_container_snapshots(monkeypatch):

--- a/tests/processor/connector/test_snapshot_aws.py
+++ b/tests/processor/connector/test_snapshot_aws.py
@@ -221,7 +221,7 @@ def test_populate_aws_snapshot(monkeypatch):
     monkeypatch.setattr('processor.connector.snapshot_aws.client', mock_client)
     monkeypatch.setattr('processor.connector.snapshot_aws.insert_one_document', mock_insert_one_document)
     from processor.connector.snapshot_aws import populate_aws_snapshot
-    val = populate_aws_snapshot(snapshot)
+    val = populate_aws_snapshot(snapshot, 'mycontainer1')
     assert val == {'8': True}
 
 
@@ -233,7 +233,7 @@ def test_exception_populate_aws_snapshot(monkeypatch):
     monkeypatch.setattr('processor.connector.snapshot_aws.client', mock_invalid_client)
     monkeypatch.setattr('processor.connector.snapshot_aws.insert_one_document', mock_insert_one_document)
     from processor.connector.snapshot_aws import populate_aws_snapshot
-    val = populate_aws_snapshot(snapshot)
+    val = populate_aws_snapshot(snapshot, 'mycontainer1')
     assert val == {'8': False}
 
 
@@ -245,7 +245,7 @@ def test_client_acceptance_from_snapshot(monkeypatch):
     monkeypatch.setattr('processor.connector.snapshot_aws.client', mock_client)
     monkeypatch.setattr('processor.connector.snapshot_aws.insert_one_document', mock_insert_one_document)
     from processor.connector.snapshot_aws import populate_aws_snapshot
-    val = populate_aws_snapshot(snapshot_with_client)
+    val = populate_aws_snapshot(snapshot_with_client, 'mycontainer1')
     assert val == {'8': True}
 
 def test_client_acceptance_from_snapshot_negative(monkeypatch):
@@ -256,5 +256,5 @@ def test_client_acceptance_from_snapshot_negative(monkeypatch):
     monkeypatch.setattr('processor.connector.snapshot_aws.client', mock_client)
     monkeypatch.setattr('processor.connector.snapshot_aws.insert_one_document', mock_insert_one_document)
     from processor.connector.snapshot_aws import populate_aws_snapshot
-    val = populate_aws_snapshot(snapshot)
+    val = populate_aws_snapshot(snapshot, 'mycontainer1')
     assert val == {'8': False}

--- a/tests/processor/connector/test_snapshot_custom.py
+++ b/tests/processor/connector/test_snapshot_custom.py
@@ -176,7 +176,7 @@ def test_populate_custom_snapshot(create_temp_dir, create_temp_json, monkeypatch
     monkeypatch.setattr('processor.connector.snapshot_custom.json_source', mock_false_json_source)
     monkeypatch.setattr('processor.connector.snapshot_custom.get_test_json_dir', mock_get_test_json_dir)
     monkeypatch.setattr('processor.connector.snapshot_custom.insert_one_document', mock_insert_one_document)
-    monkeypatch.setattr('processor.connector.snapshot_custom.get_vault_data', mock_get_vault_data)
+    # monkeypatch.setattr('processor.connector.snapshot_custom.get_vault_data', mock_get_vault_data)
     monkeypatch.setattr('processor.connector.snapshot_custom.Popen', Popen)
     from processor.connector.snapshot_custom import populate_custom_snapshot
     tmpdir = create_temp_dir()
@@ -208,9 +208,9 @@ def test_populate_custom_snapshot(create_temp_dir, create_temp_json, monkeypatch
     }
     with mock.patch('processor.connector.snapshot_custom.Repo', autospec=True) as RepoMockHelper:
         RepoMockHelper.return_value.clone_from.return_value = None
-        snapshot_data = populate_custom_snapshot(snapshot)
+        snapshot_data = populate_custom_snapshot(snapshot, 'mycontainer1')
         assert snapshot_data == {'3': False}
-        snapshot_data = populate_custom_snapshot(snapshot1)
+        snapshot_data = populate_custom_snapshot(snapshot1, 'mycontainer')
         assert snapshot_data == {}
 
 
@@ -219,7 +219,7 @@ def test_username_populate_custom_snapshot(create_temp_dir, create_temp_json, mo
     monkeypatch.setattr('processor.connector.snapshot_custom.json_source', mock_false_json_source)
     monkeypatch.setattr('processor.connector.snapshot_custom.get_test_json_dir', mock_get_test_json_dir)
     monkeypatch.setattr('processor.connector.snapshot_custom.insert_one_document', mock_insert_one_document)
-    monkeypatch.setattr('processor.connector.snapshot_custom.get_vault_data', mock_empty_get_vault_data)
+    # monkeypatch.setattr('processor.connector.snapshot_custom.get_vault_data', mock_empty_get_vault_data)
     monkeypatch.setattr('processor.connector.snapshot_custom.Popen', Popen)
     from processor.connector.snapshot_custom import populate_custom_snapshot
     tmpdir = create_temp_dir()
@@ -245,7 +245,7 @@ def test_username_populate_custom_snapshot(create_temp_dir, create_temp_json, mo
     }
     with mock.patch('processor.connector.snapshot_custom.Repo', autospec=True) as RepoMockHelper:
         RepoMockHelper.return_value.clone_from.return_value = None
-        snapshot_data = populate_custom_snapshot(snapshot)
+        snapshot_data = populate_custom_snapshot(snapshot, 'mycontainer1')
         assert snapshot_data == {'3': False}
 
 def test_populate_custom_snapshot_exception(create_temp_dir, create_temp_json, monkeypatch):
@@ -278,7 +278,7 @@ def test_populate_custom_snapshot_exception(create_temp_dir, create_temp_json, m
         ]
     }
     with mock.patch.object(Repo, 'clone_from', autospec=True, side_effect=repo_exception):
-        snapshot_data = populate_custom_snapshot(snapshot)
+        snapshot_data = populate_custom_snapshot(snapshot, 'mycontainer1')
         assert snapshot_data == {'3': False}
 
 
@@ -318,7 +318,7 @@ def test_populate_custom_snapshot_sshkey(create_temp_dir, create_temp_json, monk
     with mock.patch.object(Git, 'custom_environment', autospec=True):
         with mock.patch('processor.connector.snapshot_custom.Repo', autospec=True) as RepoMockHelper:
             RepoMockHelper.return_value.clone_from.return_value = None
-            snapshot_data = populate_custom_snapshot(snapshot)
+            snapshot_data = populate_custom_snapshot(snapshot, 'mycontainer1')
             assert snapshot_data == {'3': False}
 
 def test_populate_filesystem_custom_snapshot(create_temp_dir, create_temp_json, monkeypatch):
@@ -326,7 +326,7 @@ def test_populate_filesystem_custom_snapshot(create_temp_dir, create_temp_json, 
     monkeypatch.setattr('processor.connector.snapshot_custom.json_source', mock_false_json_source)
     monkeypatch.setattr('processor.connector.snapshot_custom.get_test_json_dir', mock_get_test_json_dir)
     monkeypatch.setattr('processor.connector.snapshot_custom.insert_one_document', mock_insert_one_document)
-    monkeypatch.setattr('processor.connector.snapshot_custom.get_vault_data', mock_get_vault_data)
+    # monkeypatch.setattr('processor.connector.snapshot_custom.get_vault_data', mock_get_vault_data)
     monkeypatch.setattr('processor.connector.snapshot_custom.Popen', Popen)
     from processor.connector.snapshot_custom import populate_custom_snapshot
     tmpdir = create_temp_dir()
@@ -362,7 +362,7 @@ def test_populate_filesystem_custom_snapshot(create_temp_dir, create_temp_json, 
     }
     with mock.patch('processor.connector.snapshot_custom.Repo', autospec=True) as RepoMockHelper:
         RepoMockHelper.return_value.clone_from.return_value = None
-        snapshot_data = populate_custom_snapshot(snapshot)
+        snapshot_data = populate_custom_snapshot(snapshot, 'mycontainer1')
         assert snapshot_data == {'5': True}
-        snapshot_data = populate_custom_snapshot(snapshot1)
+        snapshot_data = populate_custom_snapshot(snapshot1, 'mycontainer1')
         assert snapshot_data == {}

--- a/tests/processor/connector/test_validation.py
+++ b/tests/processor/connector/test_validation.py
@@ -154,7 +154,7 @@ def test_run_validation_test(monkeypatch):
     monkeypatch.setattr('processor.comparison.interpreter.get_documents',
                         mock_get_documents)
     from processor.connector.validation import run_validation_test
-    result = run_validation_test('0.1', 'validator', {}, {
+    result = run_validation_test('0.1', 'mycontainer', 'validator', {}, {
         "testId": "4",
         "snapshotId": "1",
         "attribute": "id",


### PR DESCRIPTION
The prancer-basic can be run without mongodb server.
Set the config.ini as:

[TESTS]
nodb = true


For running an example:

clone the repository
export  FRAMEWORKDIR=<clonedir>
export PYTHONPATH=<clonedir>/src
create virtualenv and install requirements.txt
python utilities/validator.py nodbcontainer
After the run
cd realm/validation/nodbcontainer
ls snapshots  # Should contain all the snapshotId json files, which will be fetched during test validation.