### PR TITLE
Jenkins ci

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.6-alpine3.10
 RUN python --version
 RUN apk update \
     && apk upgrade \
-    && apk add git
+    && apk add git build-base libffi-dev openssl-dev
 RUN pip install prancer-basic
 RUN git --version

--- a/jenkinsfiles/JenkinsfileDistribution.groovy
+++ b/jenkinsfiles/JenkinsfileDistribution.groovy
@@ -183,6 +183,20 @@ pipeline {
                 }
             }
         }
+    }
 
+    post {
+        success {
+            script {
+                echo "*** Sending success notification";
+                slackSend color: 'good', message: "cloud-validation-framework [SUCCESS] ${BUILD_URL}";
+            }
+        }
+        failure {
+            script {
+                echo "*** Sending failure notification"
+                slackSend color: 'danger', message: "cloud-validation-framework [FAILURE] ${BUILD_URL}";
+            }
+        }
     }
 }

--- a/jenkinsfiles/JenkinsfileDistribution.groovy
+++ b/jenkinsfiles/JenkinsfileDistribution.groovy
@@ -32,7 +32,11 @@ pipeline {
                     currentVersion = setupPyText.split("\n").find{ element -> element.contains("version=") }.split("=")[1].replace("'", "").replace(",", "").trim();
                     currentDirectory = pwd();
                     echo "*** Current version ${currentVersion} from setup.py. ";
-                    sh "rm dist/*";
+                    try {
+                        sh "rm dist/*";
+                    } catch(e) {
+                        echo "Warning: error trying to rm dist/*"
+                    }
                 }
             }
         }

--- a/jenkinsfiles/JenkinsfileDistribution.groovy
+++ b/jenkinsfiles/JenkinsfileDistribution.groovy
@@ -173,6 +173,12 @@ pipeline {
                     docker.withRegistry(DOCKERHUB_PUBLIC_REPOSITORY, DOCKERHUB_CREDENTIAL_ID) {
                         def customImage = docker.build("${DOCKERHUB_ORG}/${DOCKERHUB_IMAGE_NAME}:${currentVersion}", "-f dockerfiles/Dockerfile .");
                         customImage.push();
+                        // Clean image pushed from local registry
+                        try {
+                            sh "docker image rm ${DOCKERHUB_ORG}/${DOCKERHUB_IMAGE_NAME}:${currentVersion}";
+                        } catch(e) {
+                            echo "Exception with 'docker image rm' ${e}";
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Avoid to leave unused docker storage 
Update Dockerfile since Docker images were not able to be pushed to Dockerhub due to 'gcc' was started to be required.