### PR TITLE
Increase sleep to 120

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -120,6 +120,6 @@ jobs:
         id: docker_push
         run: |
           # Wait X seconds for pypi to have the binary ready
-          sleep 60
+          sleep 120
           docker login -u ${{ secrets.DOCKER_USER }} -p '${{ secrets.DOCKER_PASSWORD }}'
           docker push prancer/prancer-basic:${{ steps.read_version.outputs.VERSION }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,6 +34,14 @@ jobs:
           ref: master
           token: ${{ secrets.GIT_TOKEN }}
 
+      - name: testing
+        run: |
+          python -m pip install --upgrade pip && pip install -r requirements.txt
+          pip install pytest
+          CURPWD=`pwd`
+          export PYTHONPATH=$CURPWD/adv:$PYTHONPATH
+          py.test --cov=adv/processor_enterprise tests/ --cov-report term-missing --junitxml=junit/test-results.xml
+
       - name: install SO dependencies
         run: |
           sudo apt-get install jq


### PR DESCRIPTION
From time to time, 60 seconds is not enough to allow PyPi to tell that the artifact has been pushed already