### PR TITLE
Updated changes for httplib2 and jinja2 suggested by github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.7.1
 boto3==1.17.16
-urllib3==1.25.4
+urllib3==1.25.9
 cfn-flip==1.2.3
 gitdb2==2.0.5
 GitPython==3.1.11
@@ -21,6 +21,6 @@ oauth2client==4.1.3
 pyyaml==5.4.1
 httplib2==0.19.0
 dnspython==1.16.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 ruamel.yaml==0.16.12
 kubernetes==12.0.1


### PR DESCRIPTION
cryptography - thru azure-cli@2.0.76   - removed
rsa  - thru googleauth, oauth2client  - resolved using rsa@4.7.2 suggested rsa@4.1
py  - thru pytest and pytest-cov - resolved using py@0.10.0 , suggested py@0.10.0
httplib2 - thru google-auth-httplib - resolved using httplib2@0.19.0, suggested httplib2@0.18.0
jinja2 - direct requirement for templating - resolved using jinja2@2.11.3, suggested jinja2@2.11.3
urllib3 - thru requests - resolved using urllib3@1.25.9, suggested urllib3@1.25.9, were using urllib3@1.25.4
pyyaml  - direct requirement - resolved using 5.4.1, suggested pyyaml@5.3.1 or pyyaml@5.4
pygments - thru azure-cli@2.0.76 - resolved by removing azure-cli@2.0.76