### PR TITLE
Added sigterm handler to gracefully exit after receiving sigterm signal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LONG_DESCRIPTION = """
 setup(
     name='prancer-basic',
     # also update the version in processor.__init__.py file
-    version='1.2.2',
+    version='1.2.3',
     description='Prancer Basic, http://prancer.io/',
     long_description=LONG_DESCRIPTION,
     license = "BSD",

--- a/src/processor/__init__.py
+++ b/src/processor/__init__.py
@@ -1,3 +1,3 @@
 # Prancer Basic
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/src/processor/connector/validation.py
+++ b/src/processor/connector/validation.py
@@ -341,7 +341,7 @@ def run_container_validation_tests_database(container, snapshot_status=None):
         for doc in docs:
             test_json_data = doc['json']
             if test_json_data:
-                snapshot = doc['json']['snapshot'] if 'snapshot' in doc['json'] else ''
+                snapshot = doc['json']['masterSnapshot'] if 'masterSnapshot' in doc['json'] else ''
                 test_file = doc['name'] if 'name' in doc else '-'
                 update_output_testname(test_file, snapshot, filesystem=False)
                 try:


### PR DESCRIPTION
prancer could run for long durations when tests or resources could be huge. 
On receiving sigterm signal, updates the outputs as cancelled status and exits.