### PR TITLE
Azure cloud resources wrapped in a resource array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LONG_DESCRIPTION = """
 setup(
     name='prancer-basic',
     # also update the version in processor.__init__.py file
-    version='2.0.11',
+    version='2.0.12',
     description='Prancer Basic, http://prancer.io/',
     long_description=LONG_DESCRIPTION,
     license = "BSD",

--- a/src/processor/__init__.py
+++ b/src/processor/__init__.py
@@ -1,3 +1,3 @@
 # Prancer Basic
 
-__version__ = '2.0.11'
+__version__ = '2.0.12'

--- a/src/processor/connector/snapshot_azure.py
+++ b/src/processor/connector/snapshot_azure.py
@@ -144,7 +144,7 @@ def get_node(token, sub_name, sub_id, node, user, snapshot_source):
         "masterSnapshotId": None,
         "collection": collection.replace('.', '').lower(),
         "region" : "",
-        "json": {}  # Refactor when node is absent it should None, when empty object put it as {}
+        "json": {"resources": []}  # Refactor when node is absent it should None, when empty object put it as {}
     }
     version = get_version_for_type(node)
     if sub_id and token and node and node['path'] and version:
@@ -162,8 +162,10 @@ def get_node(token, sub_name, sub_id, node, user, snapshot_source):
         status, data = http_get_request(url, hdrs, name='\tRESOURCE:')
         # logger.info('Get Id status: %s', status)
         if status and isinstance(status, int) and status == 200:
-            db_record['json'] = data
-            db_record['region'] = db_record['json'].get("location")
+            # db_record['json'] = data
+            # db_record['region'] = db_record['json'].get("location")
+            db_record['json']['resources'].append(data)
+            db_record['region'] = data.get("location")
             data_str = json.dumps(data)
             db_record['checksum'] = hashlib.md5(data_str.encode('utf-8')).hexdigest()
         else:

--- a/tests/processor/connector/test_snapshot_azure.py
+++ b/tests/processor/connector/test_snapshot_azure.py
@@ -131,7 +131,7 @@ def test_get_node_happy(monkeypatch):
     assert True == isinstance(ret, dict)
     ret = get_node('abcd', 'devtest', 'xyz', data, 'abc', 'azureStructure')
     assert True == isinstance(ret, dict)
-    assert {'a': 'b'} == ret['json']
+    assert {'resources': [{'a': 'b'}]} == ret['json']
 
 
 def test_get_node_error(monkeypatch):
@@ -148,7 +148,7 @@ def test_get_node_error(monkeypatch):
     assert True == isinstance(ret, dict)
     ret = get_node('abcd', 'sub', 'xyz', data, 'abc', 'azureStructure')
     assert True == isinstance(ret, dict)
-    assert {} == ret['json']
+    assert {"resources": []} == ret['json']
 
 
 def test_populate_azure_snapshot(monkeypatch):


### PR DESCRIPTION
Make the structure of the cloud snapshot same as template resource, so that only one set of rego rules can be maintained.