### PR TITLE
Exclusion fixes when complianceId or masterTestID is given.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LONG_DESCRIPTION = """
 setup(
     name='prancer-basic',
     # also update the version in processor.__init__.py file
-    version='2.0.17',
+    version='2.0.18',
     description='Prancer Basic, http://prancer.io/',
     long_description=LONG_DESCRIPTION,
     license = "BSD",

--- a/src/processor/__init__.py
+++ b/src/processor/__init__.py
@@ -1,3 +1,3 @@
 # Prancer Basic
 
-__version__ = '2.0.17'
+__version__ = '2.0.18'

--- a/src/processor/comparison/interpreter.py
+++ b/src/processor/comparison/interpreter.py
@@ -589,9 +589,19 @@ class ComparatorV01:
             elif testId in self.excludedTestIds:
                 path = doc['paths'][0]
                 toExclude = True if path in self.excludedTestIds[testId] else False
+            else:
+                if 'evals' in self.testcase and self.testcase['evals']:
+                    found = False
+                    for eval in self.testcase['evals']:
+                        if eval['id'] in self.includeTests:
+                            found = True
+                            break
+                    if not found:
+                        for eval in self.testcase['evals']:
+                            if eval['id'] in self.excludedTestIds:
+                                path = doc['paths'][0]
+                                toExclude = True if path in self.excludedTestIds[eval['id']] else False
         return toExclude
-        pass
-
 
     def get_snaphotid_doc(self, sid, testId, isMasterTest=False):
         tobeExcluded = False

--- a/src/processor/connector/snapshot_azure.py
+++ b/src/processor/connector/snapshot_azure.py
@@ -124,7 +124,7 @@ def get_all_nodes(token, sub_name, sub_id, node, user, snapshot_source):
         logger.info('Get requires valid subscription, token and path.!')
     return db_records
 
-def get_node(token, sub_name, sub_id, node, user, snapshot_source, resource_array=False):
+def get_node(token, sub_name, sub_id, node, user, snapshot_source):
     """ Fetch node from azure portal using rest API."""
     collection = node['collection'] if 'collection' in node else COLLECTION
     parts = snapshot_source.split('.')
@@ -144,7 +144,7 @@ def get_node(token, sub_name, sub_id, node, user, snapshot_source, resource_arra
         "masterSnapshotId": None,
         "collection": collection.replace('.', '').lower(),
         "region" : "",
-        "json": {"resources": []}  if resource_array else {}  # Refactor when node is absent it should None, when empty object put it as {}
+        "json": {"resources": []}  # Refactor when node is absent it should None, when empty object put it as {}
     }
     version = get_version_for_type(node)
     if sub_id and token and node and node['path'] and version:
@@ -162,10 +162,7 @@ def get_node(token, sub_name, sub_id, node, user, snapshot_source, resource_arra
         status, data = http_get_request(url, hdrs, name='\tRESOURCE:')
         # logger.info('Get Id status: %s', status)
         if status and isinstance(status, int) and status == 200:
-            if resource_array:
-                db_record['json']['resources'].append(data)
-            else:
-                db_record['json'] = data
+            db_record['json']['resources'].append(data)
             db_record['region'] = data.get("location")
             data_str = json.dumps(data)
             db_record['checksum'] = hashlib.md5(data_str.encode('utf-8')).hexdigest()
@@ -181,8 +178,6 @@ def get_node(token, sub_name, sub_id, node, user, snapshot_source, resource_arra
 
 def populate_azure_snapshot(snapshot, container=None, snapshot_type='azure'):
     """ Populates the resources from azure."""
-    resource_array_env = os.getenv("RESOURCE_ARRAY", None)
-    resource_array = True if resource_array_env and resource_array_env.lower() == 'true' else False
     dbname = config_value('MONGODB', 'dbname')
     snapshot_source = get_field_value(snapshot, 'source')
     snapshot_user = get_field_value(snapshot, 'testUser')
@@ -232,7 +227,7 @@ def populate_azure_snapshot(snapshot, container=None, snapshot_type='azure'):
         for node in snapshot_nodes:
             validate = node['validate'] if 'validate' in node else True
             if 'path' in  node:
-                data = get_node(token, sub_name, sub_id, node, snapshot_user, snapshot_source, resource_array)
+                data = get_node(token, sub_name, sub_id, node, snapshot_user, snapshot_source)
                 if data:
                     if validate:
                         if get_dbtests():

--- a/tests/processor/connector/test_snapshot_azure.py
+++ b/tests/processor/connector/test_snapshot_azure.py
@@ -131,8 +131,8 @@ def test_get_node_happy(monkeypatch):
     assert True == isinstance(ret, dict)
     ret = get_node('abcd', 'devtest', 'xyz', data, 'abc', 'azureStructure')
     assert True == isinstance(ret, dict)
-    # assert {'resources': [{'a': 'b'}]} == ret['json']
-    assert {'a': 'b'} == ret['json']
+    assert {'resources': [{'a': 'b'}]} == ret['json']
+    # assert {'a': 'b'} == ret['json']
 
 
 def test_get_node_error(monkeypatch):
@@ -149,7 +149,7 @@ def test_get_node_error(monkeypatch):
     assert True == isinstance(ret, dict)
     ret = get_node('abcd', 'sub', 'xyz', data, 'abc', 'azureStructure')
     assert True == isinstance(ret, dict)
-    assert {} == ret['json']
+    assert {'resources': []} == ret['json']
 
 
 def test_populate_azure_snapshot(monkeypatch):


### PR DESCRIPTION
From the web the complianceID is given, so the exclusions were failing. 
The exclusions now take either of them and they should work fine. 
If masterTestID is given, all complianceId in the evals structure shall be excluded . 
If a complianceId is given only that eval is removed from the testcase and the rest are run. If only one complianceId is present in the testcase, the testcase is skipped. 