### PR TITLE
Multi connector fix outputs generation is fixed for terraform templates.

### DIFF
--- a/src/processor/connector/snapshot_custom.py
+++ b/src/processor/connector/snapshot_custom.py
@@ -84,6 +84,8 @@
 # Host *
 #   IdentitiesOnly yes
 #   ServerAliveInterval 100
+import string
+import random
 import json
 import hashlib
 import time
@@ -205,6 +207,8 @@ def get_node(repopath, node, snapshot, ref, connector):
 def get_all_nodes(repopath, node, snapshot, ref, connector):
     """ Fetch all the nodes from the cloned git repository in the given path."""
     db_records = []
+    charVal = (random.choice(string.ascii_letters) for x in range(4))
+    randomstr = ''.join(charVal)
     collection = node['collection'] if 'collection' in node else COLLECTION
     given_type = get_field_value(connector, "type")
     base_path = get_field_value_with_default(connector, "folderPath", "")
@@ -237,7 +241,7 @@ def get_all_nodes(repopath, node, snapshot, ref, connector):
             logger.info('type: %s, json:%s', node_type, json_data)
             if json_data:
                 db_record = copy.deepcopy(d_record)
-                db_record['snapshotId'] = '%s%s' % (node['masterSnapshotId'], str(count))
+                db_record['snapshotId'] = '%s%s%s' % (node['masterSnapshotId'], randomstr, str(count))
                 db_record['path'] = path.replace('//', '/')
                 db_record['contentType'] = contentType
                 db_record['json'] = json_data

--- a/src/processor/crawler/master_snapshot.py
+++ b/src/processor/crawler/master_snapshot.py
@@ -44,6 +44,7 @@ from processor.connector.snapshot_google import populate_google_snapshot
 from processor.connector.snapshot_kubernetes import populate_kubernetes_snapshot
 from processor.connector.populate_json import pull_json_data
 from processor.helper.file.file_utils import exists_file,remove_file
+from processor.template_processor.base.base_template_processor import set_processed_templates
 
 doc_id = None
 logger = getlogger()
@@ -132,6 +133,7 @@ def generate_mastersnapshots_from_json(mastersnapshot_json_data, snapshot_json_d
         logger.error("Json MasterSnapshot does not contain snapshots, next!...")
         return snapshot_data
     for mastersnapshot in mastersnapshots:
+        set_processed_templates({})
         current_data = generate_mastersnapshot(mastersnapshot)
         snapshot_data.update(current_data)
     # for each snapshot_json_data, update the existing json data or add the new json data here.

--- a/src/processor/template_processor/base/base_template_processor.py
+++ b/src/processor/template_processor/base/base_template_processor.py
@@ -1,3 +1,5 @@
+import random
+import string
 import re
 import subprocess
 import time
@@ -73,6 +75,8 @@ class TemplateProcessor:
         self.processed_templates = get_processed_templates()
         self.kwargs = {}
         self.folder_path = False
+        charVal = (random.choice(string.ascii_letters) for x in range(5))
+        self.randomstr = ''.join(charVal)
     
     def append_exclude_directories(self, dirs):
         """
@@ -334,7 +338,7 @@ class TemplateProcessor:
             template_node['resourceTypes'] = list(set(template_node.get('resourceTypes', [])))
             count = count + 1
             node_dict = {
-                "snapshotId": '%s%s' % (master_snapshot_id, str(count)),
+                "snapshotId": '%s%s%s' % (master_snapshot_id, self.randomstr, str(count)),
                 "type": template_node.get("node_type", self.node["type"]),
                 "collection": collection,
                 "paths": template_node["paths"],
@@ -573,7 +577,7 @@ class TemplateProcessor:
                             "validate" : self.node['validate'] if 'validate' in self.node else True
                         })
             
-            nodes, count = self.create_node_record(generated_template_file_list, count)	
+            nodes, count = self.create_node_record(generated_template_file_list, count)
             if self.node['masterSnapshotId'] not in self.snapshot_data or not isinstance(self.snapshot_data[self.node['masterSnapshotId']], list):	
                 self.snapshot_data[self.node['masterSnapshotId']] = []	
             self.snapshot_data[self.node['masterSnapshotId']] = self.snapshot_data[self.node['masterSnapshotId']] + nodes	

--- a/tests/processor/template_processor/aws/test_aws_template_processor.py
+++ b/tests/processor/template_processor/aws/test_aws_template_processor.py
@@ -118,11 +118,10 @@ def test_populate_all_template_snapshot(monkeypatch):
 
 	template_processor = AWSTemplateProcessor(node_data, **master_template_processor_kwargs)
 	snapshot_data = template_processor.populate_all_template_snapshot()
-
+	del snapshot_data['MASTER_SNAPSHOT_'][0]['snapshotId']
 	assert snapshot_data == {
 		"MASTER_SNAPSHOT_": [
 			{
-				"snapshotId": "MASTER_SNAPSHOT_1",
 				"type": "cloudformation",
 				"collection": "cloudformation",
 				"paths": [

--- a/tests/processor/template_processor/azure/test_azure_template_processor.py
+++ b/tests/processor/template_processor/azure/test_azure_template_processor.py
@@ -118,11 +118,10 @@ def test_populate_all_template_snapshot(monkeypatch):
 
 	template_processor = AzureTemplateProcessor(node_data, **master_template_processor_kwargs)
 	snapshot_data = template_processor.populate_all_template_snapshot()
-
+	del snapshot_data['MASTER_SNAPSHOT_'][0]['snapshotId']
 	assert snapshot_data == {
 		"MASTER_SNAPSHOT_": [
 			{
-				"snapshotId": "MASTER_SNAPSHOT_1",
 				"type": "arm",
 				"collection": "arm",
 				"paths": ["/sample/keyvault.json", "/sample/vars.keyvaultrg.json"],

--- a/tests/processor/template_processor/google/test_google_template_processor.py
+++ b/tests/processor/template_processor/google/test_google_template_processor.py
@@ -116,11 +116,10 @@ def test_populate_all_template_snapshot(monkeypatch):
 
 	template_processor = GoogleTemplateProcessor(node_data, **master_template_processor_kwargs)
 	snapshot_data = template_processor.populate_all_template_snapshot()
-
+	del snapshot_data['MASTER_SNAPSHOT_'][0]['snapshotId']
 	assert snapshot_data == {
 		"MASTER_SNAPSHOT_": [
 			{
-				"snapshotId": "MASTER_SNAPSHOT_1",
 				"type": "deploymentmanager",
 				"collection": "deploymentmanager",
 				"paths": ["/sample/cloudbuild.yaml"],


### PR DESCRIPTION
Fixed all snapshots being generated when paths are similar between connectors, 
Added fix for output generation when the mastersnapshot id are same and have random string for each.