### PR TITLE
log title takes meaningful names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LONG_DESCRIPTION = """
 setup(
     name='prancer-basic',
     # also update the version in processor.__init__.py file
-    version='3.0.21',
+    version='3.0.22',
     description='Prancer Basic, http://prancer.io/',
     long_description=LONG_DESCRIPTION,
     license = "BSD",

--- a/src/processor/__init__.py
+++ b/src/processor/__init__.py
@@ -1,3 +1,3 @@
 # Prancer Basic
 
-__version__ = '3.0.21'
+__version__ = '3.0.22'

--- a/src/processor/helper/utils/cli_validator.py
+++ b/src/processor/helper/utils/cli_validator.py
@@ -345,7 +345,7 @@ Run prancer for a list of snapshots
 
     # Alls well from this point, check container exists in the directory configured
     retval = 0
-    logger = init_logger(DBVALUES.index(REMOTE) if args.remote else args.db, framework_config())
+    logger = init_logger(DBVALUES.index(REMOTE) if args.remote else args.db, framework_config(), log_type='CRAWLER')
     # logger = add_file_logging(config_ini)
     logger.info("START: Argument parsing and Run Initialization. Version %s", __version__)
 
@@ -480,11 +480,12 @@ Run prancer for a list of snapshots
         
         if args.compliance or crawl_and_run:
             current_progress = 'COMPLIANCESTART'
+            logger = init_logger(DBVALUES.index(REMOTE) if args.remote else args.db, framework_config(), log_type='COMPLIANCE')
             if not crawl_and_run:
                 put_in_currentdata("run_type", COMPLIANCE)
             logger.info("Updating %s container is_run status", args.container)
             update_collection_run_status(args.db, args.container)
-            create_output_entry(args.container, test_file="-", filesystem=True if args.db ==  0 else False)
+            create_output_entry(args.container, test_file="Compliancetest_%s"%(args.container), filesystem=True if args.db ==  0 else False)
             # Normal flow
             snapshot_status = populate_container_snapshots(args.container, fs)
             logger.debug(json.dumps(snapshot_status, indent=2))

--- a/src/processor/helper/utils/compliance_utils.py
+++ b/src/processor/helper/utils/compliance_utils.py
@@ -99,8 +99,7 @@ def create_container_compliance(container, data):
 
 # def upload_compliance_results(container, opath, server, company, apitoken):
 def upload_compliance_results_multipart(container, opath, server, company, apitoken):
-    from processor.logging.log_handler import get_dblog_name, FWLOGFILENAME, FWLOGGER
-    dlog = get_dblog_name()
+    from processor.logging.log_handler import FWLOGFILENAME
     fname = FWLOGFILENAME
     name = fname.rsplit('/', 1)
     oname = opath.rsplit('/', 1)


### PR DESCRIPTION
The title of compliance logs in logs page was "-". In addition the logs were merges to crawler logs.
The PR is to change this behavior in a way that split the logs and give a appropriate name to each.