### PR TITLE
v3.1.1: Fix snapshot crash, PyPI naming, and CI pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LONG_DESCRIPTION = """
 setup(
     name='prancer_basic',
     # also update the version in processor.__init__.py file
-    version='3.1.0',
+    version='3.1.1',
     description='Prancer Basic, http://prancer.io/',
     long_description=LONG_DESCRIPTION,
     license = "BSD",

--- a/src/processor/__init__.py
+++ b/src/processor/__init__.py
@@ -1,3 +1,3 @@
 # Prancer Basic
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'

--- a/src/processor/connector/snapshot_aws.py
+++ b/src/processor/connector/snapshot_aws.py
@@ -1276,8 +1276,13 @@ def eliminate_duplicate_snapshots(snapshot_data):
     is_updated = False
     for snapshot_id, value in snapshot_data.items():
         is_updated = False
+        if not isinstance(value, list):
+            data[snapshot_id] = value
+            continue
         for count, snapshot in enumerate(value):
             for sid, sval in data.items():
+                if not isinstance(sval, list):
+                    continue
                 for cnt, val in enumerate(sval):
                     if sid == snapshot_id:
                         continue


### PR DESCRIPTION
## Summary
- **Fix `eliminate_duplicate_snapshots` crash**: Added `isinstance(value, list)` guards to prevent `TypeError: 'bool' object is not iterable` when snapshot_data contains non-list values (e.g., booleans)
- **Fix PyPI upload**: Changed package name from `prancer-basic` to `prancer_basic` in setup.py to produce valid sdist filenames
- **Fix CI pipeline**: Changed Docker test invocation from `sh` to `bash` (fixes `[[: not found` errors), added OPA binary installation in dev-test.sh
- **Fix terraform parser**: Replaced deprecated `inspect.getargspec` with `inspect.getfullargspec` for Python 3.12 compatibility
- **Fix ternary expression evaluation**: Added proper comparison operator handling (`<`, `>`, `==`, etc.) in conditional expressions instead of falling back to `bool(string)`
- **Version bump**: 3.1.0 → 3.1.1

## Test plan
- [x] Full test suite: 991 passed, 0 failed
- [ ] Verify PyPI upload produces `prancer_basic-3.1.1.tar.gz`
- [ ] Verify CI pipeline runs with OPA available in Docker containers
- [ ] Verify AWS snapshot crawling with non-list snapshot_data entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)