### PR TITLE
AWS dual-backend vault + shared platform-secret resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,11 @@ configdata/mysubscription.json
 
 log/*
 realm/*
+
+# >>> gadriel-code-security >>>
+.security/state/
+.security/audit/
+.security/metrics/
+.security/logs/
+.security/cache/
+# <<< gadriel-code-security <<<

--- a/src/processor/connector/vault.py
+++ b/src/processor/connector/vault.py
@@ -10,6 +10,8 @@ from processor.helper.config.rundata_utils import get_from_currentdata,\
 from processor.helper.config.config_utils import config_value
 from processor.helper.httpapi.restapi_azure import get_vault_access_token, get_uami_vault_access_token,\
     get_keyvault_secret, set_keyvault_secret, get_all_secrets, delete_keyvault_secret, set_keyvault_secret_with_response
+from processor.helper.httpapi.restapi_aws import get_aws_secret, set_aws_secret, set_aws_secret_with_response,\
+    delete_aws_secret, get_all_aws_secrets
 
 logger = getlogger()
 
@@ -21,6 +23,8 @@ def get_vault_data(secret_key=None):
     if vaulttype:
         if vaulttype == 'azure':
             val = get_azure_vault_data(secret_key)
+        elif vaulttype == 'aws':
+            val = get_aws_vault_data(secret_key)
         elif vaulttype == 'cyberark':
             val = get_cyberark_data(secret_key)
     return val
@@ -33,6 +37,8 @@ def set_vault_data(key_name=None, value=None):
     if vaulttype:
         if vaulttype == 'azure':
             val = set_azure_vault_data(key_name, value)
+        elif vaulttype == 'aws':
+            val = set_aws_vault_data(key_name, value)
     return val
 
 def set_vault_data_with_response(key_name=None, value=None):
@@ -42,6 +48,8 @@ def set_vault_data_with_response(key_name=None, value=None):
     if vaulttype:
         if vaulttype == 'azure':
             status, response = set_azure_vault_data_with_response(key_name, value)
+        elif vaulttype == 'aws':
+            status, response = set_aws_vault_data_with_response(key_name, value)
     return status, response
 
 def delete_vault_data(secret_key=None):
@@ -51,6 +59,8 @@ def delete_vault_data(secret_key=None):
     if vaulttype:
         if vaulttype == 'azure':
             val = delete_azure_vault_data(secret_key)
+        elif vaulttype == 'aws':
+            val = delete_aws_vault_data(secret_key)
     return val
 
 
@@ -61,7 +71,48 @@ def get_all_vault_secrets():
     if vaulttype:
         if vaulttype == 'azure':
             val = get_all_azure_secrets()
+        elif vaulttype == 'aws':
+            val = get_all_aws_vault_secrets()
     return val
+
+
+# AWS Secrets Manager dispatch helpers. Selected when [VAULT] type = aws.
+# Required config: [VAULT] aws_secrets_prefix (e.g. prancer/prod/customer170)
+# Optional: [VAULT] aws_region (else AWS_REGION env). boto3 default cred chain.
+def _aws_kwargs():
+    return {
+        'prefix': config_value('VAULT', 'aws_secrets_prefix'),
+        'region': config_value('VAULT', 'aws_region'),
+    }
+
+
+def get_aws_vault_data(secret_key=None):
+    if not secret_key:
+        return None
+    data = get_aws_secret(secret_key, **_aws_kwargs())
+    return data['value'] if data and 'value' in data else None
+
+
+def set_aws_vault_data(key_name=None, value=None):
+    if not key_name or value is None:
+        return False
+    return set_aws_secret(key_name, value, **_aws_kwargs())
+
+
+def set_aws_vault_data_with_response(key_name=None, value=None):
+    if not key_name or value is None:
+        return None, None
+    return set_aws_secret_with_response(key_name, value, **_aws_kwargs())
+
+
+def delete_aws_vault_data(secret_key=None):
+    if not secret_key:
+        return False
+    return delete_aws_secret(secret_key, **_aws_kwargs())
+
+
+def get_all_aws_vault_secrets():
+    return get_all_aws_secrets(**_aws_kwargs()) or []
 
 
 def get_all_azure_secrets():
@@ -184,3 +235,18 @@ def get_cyberark_data(secret_key=None):
         else:
             logger.info('Secret Value: %s', '*' * len(val))
     return val
+
+
+def get_platform_vault_data(secret_key=None):
+    """Account-level / platform-shared secret. On AWS resolves from the shared
+    platform prefix (default prancer/prod/platform) so one value serves every
+    tenant (used when prancer-account is not deployed). Other vault types: the
+    account vault is already shared, so defer to get_vault_data."""
+    if not secret_key:
+        return None
+    vaulttype = config_value('VAULT', 'type')
+    if vaulttype != 'aws':
+        return get_vault_data(secret_key)
+    prefix = config_value('VAULT', 'aws_platform_prefix') or 'prancer/prod/platform'
+    data = get_aws_secret(secret_key, prefix=prefix, region=config_value('VAULT', 'aws_region'))
+    return data['value'] if data and 'value' in data else None

--- a/src/processor/helper/httpapi/restapi_aws.py
+++ b/src/processor/helper/httpapi/restapi_aws.py
@@ -1,0 +1,130 @@
+"""
+AWS Secrets Manager equivalents of restapi_azure.py.
+
+Parallel implementation — does not replace the Azure path. Selected via
+[VAULT] type = aws in the config (see processor/connector/vault.py).
+
+Auth: relies on the boto3 default credential chain (env vars, IAM role via
+EKS Pod Identity / IRSA, instance profile). No explicit credential handling
+needed when running in the cluster.
+
+Secret naming convention: AWS Secrets Manager uses path-like names. The
+[VAULT] aws_secrets_prefix config value is prepended to every secret key,
+matching the V3 layout:
+
+   prancer/prod/customer170/<secret_key>
+   prancer/prod/platform/<secret_key>
+"""
+import json
+from processor.logging.log_handler import getlogger
+
+logger = getlogger()
+
+_boto3 = None
+_boto3_client_cache = {}
+
+
+def _client(service='secretsmanager', region=None):
+    global _boto3
+    if _boto3 is None:
+        try:
+            import boto3
+        except ImportError:
+            raise RuntimeError("boto3 required for [VAULT] type=aws. pip install boto3")
+        _boto3 = boto3
+    key = (service, region or 'default')
+    if key not in _boto3_client_cache:
+        kwargs = {'region_name': region} if region else {}
+        _boto3_client_cache[key] = _boto3.client(service, **kwargs)
+    return _boto3_client_cache[key]
+
+
+def _full_name(secret_key, prefix=None):
+    if not prefix:
+        return secret_key
+    if secret_key.startswith(prefix + '/') or secret_key == prefix:
+        return secret_key
+    return f"{prefix.rstrip('/')}/{secret_key.lstrip('/')}"
+
+
+def get_aws_secret(secret_key, prefix=None, region=None):
+    """Returns dict with 'value' key (parity with Azure response shape)."""
+    name = _full_name(secret_key, prefix)
+    client = _client(region=region)
+    try:
+        resp = client.get_secret_value(SecretId=name)
+        val = resp.get('SecretString')
+        if val is None:
+            binary = resp.get('SecretBinary')
+            val = binary.decode('utf-8') if binary else None
+        logger.info('AWS secret read: %s', '*' * len(name))
+        return {'value': val} if val is not None else None
+    except client.exceptions.ResourceNotFoundException:
+        logger.warning('AWS secret not found: %s', name)
+        return None
+    except Exception as e:
+        logger.error('AWS secret read failed for %s: %s', name, e)
+        return None
+
+
+def set_aws_secret(secret_key, value, prefix=None, region=None):
+    name = _full_name(secret_key, prefix)
+    client = _client(region=region)
+    try:
+        try:
+            client.put_secret_value(SecretId=name, SecretString=value)
+        except client.exceptions.ResourceNotFoundException:
+            client.create_secret(Name=name, SecretString=value)
+        logger.info('AWS secret written: %s', '*' * len(name))
+        return True
+    except Exception as e:
+        logger.error('AWS secret write failed for %s: %s', name, e)
+        return False
+
+
+def set_aws_secret_with_response(secret_key, value, prefix=None, region=None):
+    name = _full_name(secret_key, prefix)
+    client = _client(region=region)
+    try:
+        try:
+            resp = client.put_secret_value(SecretId=name, SecretString=value)
+        except client.exceptions.ResourceNotFoundException:
+            resp = client.create_secret(Name=name, SecretString=value)
+        return resp.get('ResponseMetadata', {}).get('HTTPStatusCode', 200), resp
+    except Exception as e:
+        logger.error('AWS secret write failed for %s: %s', name, e)
+        return 500, {'error': str(e)}
+
+
+def delete_aws_secret(secret_key, prefix=None, region=None, recovery_window_days=7):
+    name = _full_name(secret_key, prefix)
+    client = _client(region=region)
+    try:
+        if recovery_window_days == 0:
+            client.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
+        else:
+            client.delete_secret(SecretId=name, RecoveryWindowInDays=recovery_window_days)
+        return True
+    except client.exceptions.ResourceNotFoundException:
+        return True
+    except Exception as e:
+        logger.error('AWS secret delete failed for %s: %s', name, e)
+        return False
+
+
+def get_all_aws_secrets(prefix=None, region=None):
+    client = _client(region=region)
+    out = []
+    paginator = client.get_paginator('list_secrets')
+    filters = [{'Key': 'name', 'Values': [prefix + '/']}] if prefix else []
+    try:
+        for page in paginator.paginate(Filters=filters or None):
+            for entry in page.get('SecretList', []):
+                full_name = entry['Name']
+                short = full_name[len(prefix) + 1:] if prefix and full_name.startswith(prefix + '/') else full_name
+                val_resp = client.get_secret_value(SecretId=full_name)
+                out.append({'key': short, 'value': val_resp.get('SecretString')})
+        return out
+    except Exception as e:
+        logger.error('AWS secret list failed: %s', e)
+        return []


### PR DESCRIPTION
Adds an AWS Secrets Manager backend to the framework vault alongside the existing Azure Key Vault path (dispatched by `[VAULT] type`), plus shared platform-secret resolution — required for the customer vault to work on AWS/EKS (tokens, connector creds, etc.).

Commits: `c14b6b9` (AWS dual-backend vault) + a .gitignore tidy for gadriel `.security/` dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)